### PR TITLE
reorder default index generation continental first

### DIFF
--- a/R/generate-indices.R
+++ b/R/generate-indices.R
@@ -116,7 +116,7 @@
 generate_indices <- function(
     model_output = NULL,
     quantiles = c(0.025, 0.05, 0.25, 0.75, 0.95, 0.975),
-    regions = c("stratum", "continent"),
+    regions = c("continent","stratum"),
     regions_index = NULL,
     alternate_n = "n",
     start_year = NULL,


### PR DESCRIPTION
very simple re-ordering of the default ordering of scales in generation of indices.

Makes sense to put continent before stratum, so first indices and first plots are the highest-level summary
'
solves #11 