### PR TITLE
Hpdi

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ Imports:
     ggrepel,
     geofacet,
     ggplot2 (>= 3.4.0),
+    HDInterval,
     magrittr,
     mgcv,
     posterior (>= 1.2.1),

--- a/R/aa_common_docs.R
+++ b/R/aa_common_docs.R
@@ -42,6 +42,16 @@
 #'   integer number to be used with `withr::with_seed()` internally to ensure
 #'   reproducibility.
 #' @param quiet Logical. Suppress progress messages? Default `FALSE`.
+#' @param hpdi Logical. Should credible intervals and limits be calculated using
+#'   highest posterior density intervals instead of simple quantiles of the
+#'   posterior distribution. Default is `FALSE`. these intervals are often a
+#'   better descriptor of skewed posterior distributions, such as the predicted
+#'   mean counts that the indices represent.
+#'   Note hpd intervals are not stable for small percentages of the posterior
+#'   distribution, and so `hdpi = TRUE` is ignored for `quantiles` values
+#'   between 0.33 and 0.67 (i.e., if the `quantiles` value defines a limit for
+#'   a centered hpd interval that would include < 33% of the
+#'   posterior distribution).
 #'
 #' @details
 #' Use `@inheritParams common_docs` to include the above in any function

--- a/R/generate-indices.R
+++ b/R/generate-indices.R
@@ -366,7 +366,8 @@ if(hpdi){
        "meta_data" = append(model_output$meta_data,
                             list("regions" = regions,
                                  "start_year" = start_year,
-                                 "n_years" = n_years)),
+                                 "n_years" = n_years,
+                                 "hpdi_indices" = hpdi)),
        "meta_strata" = meta_strata,
        "raw_data" = model_output$raw_data # Original data before trimming
        )

--- a/R/generate-indices.R
+++ b/R/generate-indices.R
@@ -112,6 +112,9 @@
 #' # Generate the continental and stratum indices
 #' i <- generate_indices(pacific_wren_model)
 #'
+#' # Generate the continental and stratum indices using hpdi
+#' i <- generate_indices(pacific_wren_model, hpdi = TRUE)
+#'
 #' # Generate only country indices
 #' i_nat <- generate_indices(pacific_wren_model, regions = "country")
 #'

--- a/R/generate-indices.R
+++ b/R/generate-indices.R
@@ -53,16 +53,6 @@
 #'   is `FALSE` (regions are flagged and listed but not dropped).
 #' @param start_year Numeric. Trim the data record before calculating annual
 #'   indices.
-#' @param hpdi Logical. Should credible intervals and limits be calculated using
-#'   highest posterior density intervals instead of simple quantiles of the
-#'   posterior distribution. Default is `FALSE`. these intervals are often a
-#'   better descriptor of skewed posterior distributions, such as the predicted
-#'   mean counts that the indices represent.
-#'   Note hpd intervals are not stable for small percentages of the posterior
-#'   distribution, and so `hdpi = TRUE` is ignored for `quantiles` values
-#'   between 0.33 and 0.67 (i.e., if the `quantiles` value defines a limit for
-#'   a centered hpd interval that would include < 33% of the
-#'   posterior distribution).
 #'
 #' @inheritParams common_docs
 #' @family indices and trends functions
@@ -406,28 +396,6 @@ calc_weights <- function(data, n) {
 }
 
 
-# function to calculate the highest posterior density interval for the quantiles
-# these intervals are often a better descriptor of skewed posterior distributions
-interval_function_hpdi <- function(x,probs = 0.025){
-  y <- vector("numeric",length = length(probs))
-  names(y) <- paste0(probs*100,"%")
-  for(j in 1:length(probs)){
-    prob <- probs[j]
-    if(prob > 0.67 | prob < 0.33){
-      if(prob < 0.25){
-        q2 <- 1-(prob*2)
-        i <- 1
-      }else{
-        q2 <- 1-((1-prob)*2)
-        i <- 2
-      }
-      y[j] <- HDInterval::hdi(x,q2)[i]
-    }else{
-      y[j] <- stats::quantile(x,prob)
-    }
-  }
-    return(y)
-  }
 
 calc_quantiles_hpdi <- function(N, quantiles) {
   apply(N, 2, interval_function_hpdi, probs = c(quantiles, 0.5)) %>%

--- a/R/generate-indices.R
+++ b/R/generate-indices.R
@@ -53,6 +53,16 @@
 #'   is `FALSE` (regions are flagged and listed but not dropped).
 #' @param start_year Numeric. Trim the data record before calculating annual
 #'   indices.
+#' @param hpdi Logical. Should credible intervals and limits be calculated using
+#'   highest posterior density intervals instead of simple quantiles of the
+#'   posterior distribution. Default is `FALSE`. these intervals are often a
+#'   better descriptor of skewed posterior distributions, such as the predicted
+#'   mean counts that the indices represent.
+#'   Note hpd intervals are not stable for small percentages of the posterior
+#'   distribution, and so `hdpi = TRUE` is ignored for `quantiles` values
+#'   between 0.33 and 0.67 (i.e., if the `quantiles` value defines a limit for
+#'   a centered hpd interval that would include < 33% of the
+#'   posterior distribution).
 #'
 #' @inheritParams common_docs
 #' @family indices and trends functions
@@ -60,10 +70,10 @@
 #' @details
 #'   `max_backcast` is a way to deal with the fact that the species of interest
 #'   may not appear in the data until several years after the start of the
-#'   record. `max_backcast` specifies how many years can occur before the
+#'   time-series `max_backcast` specifies how many years can occur before the
 #'   stratum is flagged. A `max_backcast` of 5 will flag any stratum without a
-#'   non-zero (or non-NA) observation within the first 5 years of the data
-#'   record. Note that records are *only* flagged unless `drop_exclude = TRUE`.
+#'   non-zero (or non-NA) observation within the first 5 years of the time-
+#'   series. Note that records are *only* flagged unless `drop_exclude = TRUE`.
 #'   If you find that the early data record is sparse and results in the
 #'   exclusion of many strata, consider trimming the early years by specifying a
 #'   `start_year`.
@@ -136,15 +146,16 @@ generate_indices <- function(
     regions_index = NULL,
     alternate_n = "n",
     start_year = NULL,
-    drop_exclude = FALSE,
     max_backcast = NULL,
+    drop_exclude = FALSE,
+    hpdi = FALSE,
     quiet = FALSE) {
 
   # Checks
   check_data(model_output)
   check_numeric(quantiles)
   check_numeric(start_year, max_backcast, allow_null = TRUE)
-  check_logical(drop_exclude, quiet)
+  check_logical(drop_exclude, quiet, hpdi)
 
   # Get data
   stratify_by <- model_output$meta_data$stratify_by
@@ -316,7 +327,11 @@ generate_indices <- function(
                                 "n_non_zero", "flag_year"),
                       ~ sum(.x, na.rm = TRUE)),
         .groups = "drop")
-
+if(hpdi){
+  calc_quantiles <- calc_quantiles_hpdi
+}else{
+  calc_quantiles <- calc_quantiles_original
+}
     # Calculate sample statistics for this composite region
     samples <- meta_strata_sub %>%
       # Create back up col for use in calculations
@@ -390,13 +405,46 @@ calc_weights <- function(data, n) {
   apply(n_weight, c(1, 3), sum)
 }
 
-calc_quantiles <- function(N, quantiles) {
+
+# function to calculate the highest posterior density interval for the quantiles
+# these intervals are often a better descriptor of skewed posterior distributions
+interval_function_hpdi <- function(x,probs = 0.025){
+  y <- vector("numeric",length = length(probs))
+  names(y) <- paste0(probs*100,"%")
+  for(j in 1:length(probs)){
+    prob <- probs[j]
+    if(prob > 0.67 | prob < 0.33){
+      if(prob < 0.25){
+        q2 <- 1-(prob*2)
+        i <- 1
+      }else{
+        q2 <- 1-((1-prob)*2)
+        i <- 2
+      }
+      y[j] <- HDInterval::hdi(x,q2)[i]
+    }else{
+      y[j] <- stats::quantile(x,prob)
+    }
+  }
+    return(y)
+  }
+
+calc_quantiles_hpdi <- function(N, quantiles) {
+  apply(N, 2, interval_function_hpdi, probs = c(quantiles, 0.5)) %>%
+    t() %>%
+    as.data.frame() %>%
+    stats::setNames(c(paste0("index_q_", quantiles), "index")) %>%
+    dplyr::bind_cols(year = as.numeric(dimnames(N)$year))
+}
+
+calc_quantiles_original <- function(N, quantiles) {
   apply(N, 2, stats::quantile, probs = c(quantiles, 0.5)) %>%
     t() %>%
     as.data.frame() %>%
     stats::setNames(c(paste0("index_q_", quantiles), "index")) %>%
     dplyr::bind_cols(year = as.numeric(dimnames(N)$year))
 }
+
 
 calc_alt_names <- function(r, region_names) {
   col_region_name <- dplyr::case_when(r == "prov_state" ~ "province_state",

--- a/R/generate-trends.R
+++ b/R/generate-trends.R
@@ -300,7 +300,8 @@ generate_trends <- function(indices,
 
 
   list("trends" = trends,
-       "meta_data" = indices[["meta_data"]],
+       "meta_data" = append(indices[["meta_data"]],
+                            list("hpdi_trends" = hpdi)),
        "meta_strata" = indices[["meta_strata"]],
        "raw_data" = indices[["raw_data"]])
 }

--- a/R/plot-geofacet.R
+++ b/R/plot-geofacet.R
@@ -81,8 +81,10 @@ plot_geofacet <- function(indices,
   if(!is.null(trends)) {
 
     check_data(trends)
+    t_meta_data <- trends$meta_data
+    t_meta_data$hpdi_trends <- NULL
 
-    if(any(unlist(trends$meta_data) != unlist(indices$meta_data))) {
+    if(any(unlist(t_meta_data) != unlist(indices$meta_data))) {
       stop("`trends` data must have been created from the same `indices` ",
            "used here.\n",
            "Meta data doesn't match (see `",

--- a/R/plot-map.R
+++ b/R/plot-map.R
@@ -128,7 +128,7 @@ plot_map <- function(trends,
                    axis.title = ggplot2::element_blank()) +
     ggplot2::guides(fill = ggplot2::guide_legend(reverse = TRUE))
   if(!col_viridis) {
-    pal <- setNames(
+    pal <- stats::setNames(
       c("#a50026", "#d73027", "#f46d43", "#fdae61", "#fee090", "#ffffbf",
         "#e0f3f8", "#abd9e9", "#74add1", "#4575b4", "#313695"),
       levels(map$t_plot))

--- a/R/utils.R
+++ b/R/utils.R
@@ -26,3 +26,29 @@ format_ne_states <- function() {
     dplyr::mutate(prov_state = dplyr::if_else(
       .data$prov_state == "NF", "NL", .data$prov_state))
 }
+
+
+# function to calculate the highest posterior density interval for the quantiles
+# these intervals are often a better descriptor of skewed posterior distributions
+interval_function_hpdi <- function(x,probs, names = TRUE){
+  y <- vector("numeric",length = length(probs))
+  if(names){
+    names(y) <- paste0(probs*100,"%")
+  }
+  for(j in 1:length(probs)){
+    prob <- probs[j]
+    if(prob > 0.67 | prob < 0.33){
+      if(prob < 0.33){
+        q2 <- 1-(prob*2)
+        i <- 1
+      }else{
+        q2 <- 1-((1-prob)*2)
+        i <- 2
+      }
+      y[j] <- HDInterval::hdi(x,q2)[i]
+    }else{
+      y[j] <- stats::quantile(x,prob)
+    }
+  }
+  return(y)
+}

--- a/man/common_docs.Rd
+++ b/man/common_docs.Rd
@@ -61,6 +61,17 @@ integer number to be used with \code{withr::with_seed()} internally to ensure
 reproducibility.}
 
 \item{quiet}{Logical. Suppress progress messages? Default \code{FALSE}.}
+
+\item{hpdi}{Logical. Should credible intervals and limits be calculated using
+highest posterior density intervals instead of simple quantiles of the
+posterior distribution. Default is \code{FALSE}. these intervals are often a
+better descriptor of skewed posterior distributions, such as the predicted
+mean counts that the indices represent.
+Note hpd intervals are not stable for small percentages of the posterior
+distribution, and so \code{hdpi = TRUE} is ignored for \code{quantiles} values
+between 0.33 and 0.67 (i.e., if the \code{quantiles} value defines a limit for
+a centered hpd interval that would include < 33\% of the
+posterior distribution).}
 }
 \description{
 Common arguments and documentation for various functions

--- a/man/generate_indices.Rd
+++ b/man/generate_indices.Rd
@@ -153,6 +153,9 @@ exclusion of many strata, consider trimming the early years by specifying a
 # Generate the continental and stratum indices
 i <- generate_indices(pacific_wren_model)
 
+# Generate the continental and stratum indices using hpdi
+i <- generate_indices(pacific_wren_model, hpdi = TRUE)
+
 # Generate only country indices
 i_nat <- generate_indices(pacific_wren_model, regions = "country")
 

--- a/man/generate_indices.Rd
+++ b/man/generate_indices.Rd
@@ -11,8 +11,9 @@ generate_indices(
   regions_index = NULL,
   alternate_n = "n",
   start_year = NULL,
-  drop_exclude = FALSE,
   max_backcast = NULL,
+  drop_exclude = FALSE,
+  hpdi = FALSE,
   quiet = FALSE
 )
 }
@@ -64,16 +65,27 @@ time-periods.}
 \item{start_year}{Numeric. Trim the data record before calculating annual
 indices.}
 
-\item{drop_exclude}{Logical. Whether or not strata that exceed the
-\code{max_backcast} threshold should be excluded from the calculations. Default
-is \code{FALSE} (regions are flagged and listed but not dropped).}
-
 \item{max_backcast}{Numeric. The number of years to back cast stratum-level
 estimates before the first year that species was observed on any route in
 that stratum. Default is \code{NULL}, which generates annual indices for the
 entire time series and ignores back-casting. CWS national estimates use a
 back cast of 5. Note that unless \code{drop_exclude = TRUE}, problematic years
 are only flagged, not omitted. See Details for more specifics.}
+
+\item{drop_exclude}{Logical. Whether or not strata that exceed the
+\code{max_backcast} threshold should be excluded from the calculations. Default
+is \code{FALSE} (regions are flagged and listed but not dropped).}
+
+\item{hpdi}{Logical. Should credible intervals and limits be calculated using
+highest posterior density intervals instead of simple quantiles of the
+posterior distribution. Default is \code{FALSE}. these intervals are often a
+better descriptor of skewed posterior distributions, such as the predicted
+mean counts that the indices represent.
+Note hpd intervals are not stable for small percentages of the posterior
+distribution, and so \code{hdpi = TRUE} is ignored for \code{quantiles} values
+between 0.33 and 0.67 (i.e., if the \code{quantiles} value defines a limit for
+a centered hpd interval that would include < 33\% of the
+posterior distribution).}
 
 \item{quiet}{Logical. Suppress progress messages? Default \code{FALSE}.}
 }
@@ -127,10 +139,10 @@ species, and to estimate trends.
 \details{
 \code{max_backcast} is a way to deal with the fact that the species of interest
 may not appear in the data until several years after the start of the
-record. \code{max_backcast} specifies how many years can occur before the
+time-series \code{max_backcast} specifies how many years can occur before the
 stratum is flagged. A \code{max_backcast} of 5 will flag any stratum without a
-non-zero (or non-NA) observation within the first 5 years of the data
-record. Note that records are \emph{only} flagged unless \code{drop_exclude = TRUE}.
+non-zero (or non-NA) observation within the first 5 years of the time-
+series. Note that records are \emph{only} flagged unless \code{drop_exclude = TRUE}.
 If you find that the early data record is sparse and results in the
 exclusion of many strata, consider trimming the early years by specifying a
 \code{start_year}.

--- a/man/generate_trends.Rd
+++ b/man/generate_trends.Rd
@@ -11,7 +11,8 @@ generate_trends(
   quantiles = c(0.025, 0.05, 0.25, 0.75, 0.95, 0.975),
   slope = FALSE,
   prob_decrease = NULL,
-  prob_increase = NULL
+  prob_increase = NULL,
+  hpdi = FALSE
 )
 }
 \arguments{
@@ -53,6 +54,17 @@ optionally calculate the posterior probabilities (see Details). Default is
 \item{prob_increase}{Numeric vector. Percent-increase values for which to
 optionally calculate the posterior probabilities (see Details). Default is
 \code{NULL} (not calculated). Can range from 0 to Inf.}
+
+\item{hpdi}{Logical. Should credible intervals and limits be calculated using
+highest posterior density intervals instead of simple quantiles of the
+posterior distribution. Default is \code{FALSE}. these intervals are often a
+better descriptor of skewed posterior distributions, such as the predicted
+mean counts that the indices represent.
+Note hpd intervals are not stable for small percentages of the posterior
+distribution, and so \code{hdpi = TRUE} is ignored for \code{quantiles} values
+between 0.33 and 0.67 (i.e., if the \code{quantiles} value defines a limit for
+a centered hpd interval that would include < 33\% of the
+posterior distribution).}
 }
 \value{
 A list containing


### PR DESCRIPTION
## Description
Adding the option to use highest posterior density intervals instead of quantiles for `generate_indices()` and `generate_trends()`.

## Related Issue
closes issue #26 

## Example
generate_trends(i, hpdi = TRUE)

## Best Practices
Documentation is updated, and example added to generate_indices
meta_data from `generate_indices()` and `generate_trends()` now includes a logical indicator tracking which quantiles are used
function to calculate hpdi are added to utils.R and common_docs
