### PR TITLE
fixing subset stratification bug

### DIFF
--- a/R/stratify.R
+++ b/R/stratify.R
@@ -310,13 +310,9 @@ stratify <- function(by,
     strata_custom <- stratify_map(bbsBayes2::load_map(stratify_by), routes,
                                   quiet, stratify_type, distance_to_strata)
     routes <- strata_custom[["routes"]]
+    meta_strata <- strata_custom[["meta_strata"]]
 
-    if(stratify_type == "subset") {
-      meta_strata <- strata_custom %>%
-        sf::st_drop_geometry()
-    } else {
-      meta_strata <- bbsBayes2::bbs_strata[[stratify_by]]
-    }
+
 
 
   }


### PR DESCRIPTION
bug fix for stratification using a subset of one of the base stratifications.
bug in stratify() that returned a list instead of an `sf` object when use_map = TRUE
