### PR TITLE
adding non-interactive option to fetch_bbs_data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bbsBayes2
 Type: Package
 Title: Hierarchical Bayesian Analysis of North American BBS Data
-Version: 1.2026.1
+Version: 1.2026.2
 Authors@R: c(person("Brandon P.M.", "Edwards", role = c("aut", "cre"),
                      email = "brandonedwards3@cmail.carleton.ca"),
               person("Adam C.", "Smith", role = "aut",

--- a/R/fetch-bbs-data.R
+++ b/R/fetch-bbs-data.R
@@ -22,6 +22,10 @@
 #'   understand the information in at least the following columns of the route
 #'   survey info: RouteTypeID, RouteTypeDetailID, RPID, RunType, and the rest
 #'   of the information in the data release meta data.
+#' @param interactive Logical. Default is TRUE, to allow users to see and agree
+#'   to the data terms. If set to FALSE, then the download takes place without
+#'   the user's input, useful for scripted processes such as running analyses
+#'   in HPC environments or building containers.
 #'
 #' @inheritParams common_docs
 #' @family BBS data functions
@@ -70,15 +74,17 @@ fetch_bbs_data <- function(level = "state",
                            force = FALSE,
                            quiet = FALSE,
                            compression = "none",
-                           include_unacceptable = FALSE) {
+                           include_unacceptable = FALSE,
+                           interactive = TRUE) {
 
   check_in(level, c("state", "stop"))
   check_release(release)
 
-  check_logical(c(quiet, force))
+  check_logical(c(quiet, force, interactive))
 
   out_file <- check_bbs_data(level, release, force, quiet)
 
+  if(interactive){
   # Print Terms of Use
   terms <- readChar(system.file(paste0("data-terms-",release),
                                 package = "bbsBayes2"),
@@ -88,7 +94,7 @@ fetch_bbs_data <- function(level = "state",
   message(terms)
   agree <- readline(prompt = "Type \"yes\" (without quotes) to agree: ")
   if(agree != "yes") return(NULL)
-
+  }
   fetch_bbs_data_internal(level, release, force, quiet, out_file, compression,
                           include_unacceptable)
 }

--- a/man/fetch_bbs_data.Rd
+++ b/man/fetch_bbs_data.Rd
@@ -10,7 +10,8 @@ fetch_bbs_data(
   force = FALSE,
   quiet = FALSE,
   compression = "none",
-  include_unacceptable = FALSE
+  include_unacceptable = FALSE,
+  interactive = TRUE
 )
 }
 \arguments{
@@ -41,6 +42,11 @@ the BBS data that do not fit the BBS structured survey design, be sure you
 understand the information in at least the following columns of the route
 survey info: RouteTypeID, RouteTypeDetailID, RPID, RunType, and the rest
 of the information in the data release meta data.}
+
+\item{interactive}{Logical. Default is TRUE, to allow users to see and agree
+to the data terms. If set to FALSE, then the download takes place without
+the user's input, useful for scripted processes such as running analyses
+in HPC environments or building containers.}
 }
 \description{
 Fetch and download Breeding Bird Survey data from the United States


### PR DESCRIPTION
Very small change to allow for a non-interactive application of `fetch_bbs_data(interactive = FALSE)`

The default is TRUE, so the original process is unchanged. The FALSE option should be helpful for building containers, running in an HPC environment or other scripted processes where interactive download is difficult.

